### PR TITLE
Fix currentBranch being an empty string on fresh installs.

### DIFF
--- a/ProjectSrc/Installer/RobloxStudioInstaller.cs
+++ b/ProjectSrc/Installer/RobloxStudioInstaller.cs
@@ -705,6 +705,7 @@ namespace RobloxStudioModManager
             echo("Checking build installation...");
 
             string currentBranch = Program.GetString("BuildBranch");
+            if (string.IsNullOrEmpty(currentBranch)) currentBranch = "roblox";
             string currentVersion = versionRegistry.GetString("VersionGuid");
 
             bool shouldInstall = (forceInstall || currentBranch != branch);


### PR DESCRIPTION
`currentBranch` is an empty string for fresh installs of Roblox Studio Mod Manager, causing an exception in GetFastVersionGuid.

This fixes that (might want to make a better fix for this to set BuildBranch earlier to fix this issue better, but whatever)