### PR TITLE
Fix (another) NRE in GetFastVersionGuid

### DIFF
--- a/ProjectSrc/Installer/RobloxStudioInstaller.cs
+++ b/ProjectSrc/Installer/RobloxStudioInstaller.cs
@@ -707,11 +707,11 @@ namespace RobloxStudioModManager
             string currentBranch = Program.GetString("BuildBranch");
             string currentVersion = versionRegistry.GetString("VersionGuid");
 
+            if (string.IsNullOrWhiteSpace(currentBranch))
+                currentBranch = "roblox";
+
             bool shouldInstall = (forceInstall || currentBranch != branch);
             string fastVersion = await GetFastVersionGuid(currentBranch);
-            
-            if (currentBranch == null)
-                currentBranch = "roblox";
                 
             if (branch == "roblox")
                 buildVersion = fastVersion;


### PR DESCRIPTION
This fixes the same issue that was attempted to be fixed in the last pull request I did, but the regression was reintroduced, so I made a better fix this time around.

The check to set the branch to Roblox if the setting was null was done after GetFastVersionGuid, causing an exception for new users of the mod manager.