### PR TITLE
Fixed 3rd line bug

### DIFF
--- a/ProjectSrc/Forms/FlagEditor.cs
+++ b/ProjectSrc/Forms/FlagEditor.cs
@@ -500,9 +500,9 @@ namespace RobloxStudioModManager
                 if (flagType.EndsWith("Flag", Program.StringFormat) && cellType != typeof(DataGridViewTextBoxCell))
                 {
                     var newValueCell = new DataGridViewTextBoxCell();
+                    newValueCell.Value = valueCell.Value.ToString();
                     row.Cells[2] = newValueCell;
 
-                    newValueCell.Value = valueCell.Value.ToString();
                     newValueCell.ReadOnly = true;
                 }
             }


### PR DESCRIPTION
Fixed the bug where modifying the 3rd line of the flag editor will not work. I have not not modified the file `RobloxStudioModManager.exe` so you will need to compile it yourself.
Fixes #82 